### PR TITLE
fix setNormalDisplay() for SH1107H (v2.1 displays)

### DIFF
--- a/SeeedGrayOLED.cpp
+++ b/SeeedGrayOLED.cpp
@@ -470,7 +470,11 @@ void SeeedGrayOLED::deactivateScroll() {
 }
 
 void SeeedGrayOLED::setNormalDisplay() {
-    sendCommand(SeeedGrayOLED_Normal_Display_Cmd);
+    if (Drive_IC == SSD1327) {
+        sendCommand(SeeedGrayOLED_Normal_Display_Cmd);
+    } else if (Drive_IC == SH1107G) {
+        sendCommand(SeeedGrayOLED_Normal_Display_Cmd_SH1107G);
+    }
 }
 
 void SeeedGrayOLED::setInverseDisplay() {


### PR DESCRIPTION
the function setNormalDisplay() need to differentiate the command for the two versions of the display. the command was luckily already referenced in the header.